### PR TITLE
Support `10.0.18363.836`: Has no `IVirtualDesktopManagerInternal2` manager

### DIFF
--- a/pyvda/com_defns.py
+++ b/pyvda/com_defns.py
@@ -62,12 +62,14 @@ def get_windows_build() -> int:
 
 if not os.getenv("READTHEDOCS"):
     build = get_windows_build()
+    BUILD_OVER_19041 = build >= 19041
     BUILD_OVER_20231 = build >= 20231
     BUILD_OVER_21313 = build >= 21313
     BUILD_OVER_22449 = build >= 22449
     BUILD_OVER_22621 = build >= 22621
     BUILD_OVER_22631 = build >= 22631
 else:
+    BUILD_OVER_19041 = False
     BUILD_OVER_20231 = False
     BUILD_OVER_21313 = False
     BUILD_OVER_22449 = False

--- a/pyvda/pyvda.py
+++ b/pyvda/pyvda.py
@@ -10,6 +10,7 @@ from .com_defns import (
     IApplicationView,
     IVirtualDesktop,
     IVirtualDesktop2,
+    BUILD_OVER_19041,
     BUILD_OVER_21313,
 )
 from .utils import Managers
@@ -323,9 +324,15 @@ class VirtualDesktop():
 
         Returns:
             str: The desktop name.
+
+        Raises:
+            NotImplementedError: If the Windows version is < 19041.
         """
         if BUILD_OVER_21313:
             return str(self._virtual_desktop.GetName())
+
+        if not BUILD_OVER_19041:
+            raise NotImplementedError(f"{VirtualDesktop.name.__name__} is not supported on < 19041 versions")
 
         array = managers.manager_internal.get_all_desktops()
         for vd in array.iter(IVirtualDesktop2):
@@ -339,7 +346,13 @@ class VirtualDesktop():
 
         Args:
             name: The new name for this desktop.
+
+        Raises:
+            NotImplementedError: If the Windows version is < 19041.
         """
+        if not BUILD_OVER_19041:
+            raise NotImplementedError(f"{VirtualDesktop.rename.__name__} is not supported on < 19041 versions")
+
         if BUILD_OVER_21313:
             managers.manager_internal.SetName(self._virtual_desktop, HSTRING(name))
         else:

--- a/pyvda/utils.py
+++ b/pyvda/utils.py
@@ -18,6 +18,7 @@ from .com_defns import (
     IServiceProvider,
     CLSID_ImmersiveShell,
     CLSID_VirtualDesktopManagerInternal,
+    BUILD_OVER_19041,
     BUILD_OVER_21313,
 )
 
@@ -68,7 +69,7 @@ class Managers(threading.local):
         self.pinned_apps = get_pinned_apps()
 
         # Old interface only used for SetName
-        if not BUILD_OVER_21313:
+        if not BUILD_OVER_21313 and BUILD_OVER_19041:
             self.manager_internal2 = get_vd_manager_internal2()
 
     @staticmethod

--- a/tests/test_desktop_functions.py
+++ b/tests/test_desktop_functions.py
@@ -9,6 +9,9 @@ from pyvda import (
 import time
 import win32gui
 import threading
+import pytest
+
+from pyvda.com_defns import BUILD_OVER_19041
 
 current_window = AppView.current()
 current_desktop = VirtualDesktop.current()
@@ -93,6 +96,13 @@ def test_create_and_remove_desktop():
     time.sleep(1) # Got to wait for the animation before we can return
     current_desktop.go()
 
+
+@pytest.mark.xfail(
+    condition=not BUILD_OVER_19041,
+    reason="<=18363 has no IVirtualDesktopManagerInternal2 manager",
+    raises=NotImplementedError,
+    strict=True
+)
 def test_desktop_names():
     current_name = current_desktop.name
     test_name = "pyvda testing"
@@ -100,6 +110,7 @@ def test_desktop_names():
     assert current_desktop.name == test_name, f"Wanted '{test_name}', got '{current_desktop.name}'"
     current_desktop.rename(current_name)
     assert current_desktop.name == current_name, f"Wanted '{current_name}', got '{current_desktop.name}'"
+
 
 def test_move_and_go_threads():
     error: Optional[Exception] = None


### PR DESCRIPTION
`raise NotImplementedError` on `.name` and `.rename` methods.

Fixes https://github.com/mrob95/pyvda/issues/37

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>