### PR TITLE
feat: add animation option for desktop switching

### DIFF
--- a/pyvda/com_defns.py
+++ b/pyvda/com_defns.py
@@ -9,8 +9,6 @@ References:
         * http://grabacr.net/archives/5601
         * https://www.cyberforum.ru/blogs/105416/blog3671.html
 """
-import os
-import sys
 from ctypes import HRESULT, POINTER, c_ulonglong
 from ctypes.wintypes import (
     BOOL,
@@ -205,7 +203,6 @@ class IVirtualDesktopManagerInternal(IUnknown):
             COMMETHOD([], HRESULT, "SetWallpaperForAllDesktops", (["in"], HSTRING, "path")),
             COMMETHOD([], HRESULT, "CopyDesktopState", (["in"], POINTER(IApplicationView), "pView0"), (["in"], POINTER(IApplicationView), "pView0")),
             COMMETHOD([], HRESULT, "CreateRemoteDesktop", (["in"], HSTRING, "a1"), (["out"], POINTER(POINTER(IVirtualDesktop)), "out")),
-            STDMETHOD(HRESULT, "pDesktop", (POINTER(IVirtualDesktop),)),
             STDMETHOD(HRESULT, "SwitchRemoteDesktop", (POINTER(IVirtualDesktop), UINT)),
             STDMETHOD(HRESULT, "SwitchDesktopWithAnimation", (POINTER(IVirtualDesktop),)),
             COMMETHOD([], HRESULT, "GetLastActiveDesktop", (["out"], POINTER(POINTER(IVirtualDesktop)), "pDesktop"),),
@@ -230,7 +227,6 @@ class IVirtualDesktopManagerInternal(IUnknown):
             COMMETHOD([], HRESULT, "SetWallpaperForAllDesktops", (["in"], HSTRING, "path")),
             COMMETHOD([], HRESULT, "CopyDesktopState", (["in"], POINTER(IApplicationView), "pView0"), (["in"], POINTER(IApplicationView), "pView0")),
             COMMETHOD([], HRESULT, "CreateRemoteDesktop", (["in"], HSTRING, "a1"), (["out"], POINTER(POINTER(IVirtualDesktop)), "out")),
-            STDMETHOD(HRESULT, "pDesktop", (POINTER(IVirtualDesktop),)),
             STDMETHOD(HRESULT, "SwitchRemoteDesktop", (POINTER(IVirtualDesktop), UINT)),
             STDMETHOD(HRESULT, "SwitchDesktopWithAnimation", (POINTER(IVirtualDesktop),)),
             COMMETHOD([], HRESULT, "GetLastActiveDesktop", (["out"], POINTER(POINTER(IVirtualDesktop)), "pDesktop"),),
@@ -360,6 +356,18 @@ class IVirtualDesktopManagerInternal(IUnknown):
             return self.SwitchDesktop(0, target) # type: ignore
         else:
             return self.SwitchDesktop(target) # type: ignore
+
+    def switch_desktop_with_animation(self, target: IVirtualDesktop):
+        """Switch to a virtual desktop with animation.
+        
+        Only available on Windows 11 builds 22631 and later.
+        """
+        if build.OVER_22631:
+            return self.SwitchDesktopWithAnimation(target) # type: ignore
+        else:
+            raise NotImplementedError(
+                "SwitchDesktopWithAnimation is only available on Windows 11 build 22631 and later"
+            )
 
 
 GUID_IVirtualDesktopManagerInternal2 = GUID("{0F3A72B0-4566-487E-9A33-4ED302F6D6CE}")

--- a/pyvda/pyvda.py
+++ b/pyvda/pyvda.py
@@ -40,7 +40,7 @@ class AppView():
         elif view:
             self._view = view
         else:
-            raise Exception(f"Must pass 'hwnd' or 'view'")
+            raise Exception("Must pass 'hwnd' or 'view'")
 
     def __eq__(self, other):
         return self.hwnd == other.hwnd
@@ -385,18 +385,22 @@ class VirtualDesktop():
             fallback = VirtualDesktop(1)
         managers.manager_internal.RemoveDesktop(self._virtual_desktop, fallback._virtual_desktop) # type: ignore
 
-    def go(self, allow_set_foreground: bool = True):
+    def go(self, allow_set_foreground: bool = True, animation: bool = False):
         """Switch to this virtual desktop.
 
         Args:
             allow_set_foreground (bool, optional): Call AllowSetForegroundWindow(ASFW_ANY) before switching. This partially fixes an issue where the focus remains behind after switching. Defaults to True.
+            animation (bool, optional): Use the Windows desktop switching animation. Only available on Windows 11 build 22631 and later. Defaults to False.
 
         Note:
             More details at https://github.com/Ciantic/VirtualDesktopAccessor/issues/4 and https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-allowsetforegroundwindow.
         """
         if allow_set_foreground:
             windll.user32.AllowSetForegroundWindow(ASFW_ANY)
-        managers.manager_internal.switch_desktop(self._virtual_desktop) # type: ignore
+        if animation:
+            managers.manager_internal.switch_desktop_with_animation(self._virtual_desktop) # type: ignore
+        else:
+            managers.manager_internal.switch_desktop(self._virtual_desktop) # type: ignore
 
     def apps_by_z_order(self, include_pinned: bool = True) -> List[AppView]:
         """Get a list of AppViews, ordered by their Z position, with


### PR DESCRIPTION
- Introduced a new parameter `animation` to the `go` method in the VirtualDesktop class.
- Added a new method `switch_desktop_with_animation` to enable desktop switching with animation on Windows 11 builds 22631 and later.
- Removed unused imports from com_defns.py.