### PR TITLE
fix: support multi-window and XAML Island application pinning

### DIFF
--- a/pyvda/__init__.py
+++ b/pyvda/__init__.py
@@ -61,4 +61,5 @@ from .pyvda import (
     get_apps_by_z_order,
     get_virtual_desktops,
     set_wallpaper_for_all_desktops,
+    sync_pinned_apps,
 )

--- a/pyvda/pyvda.py
+++ b/pyvda/pyvda.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from ctypes import windll
-from typing import List, Optional
+from typing import Dict, List, Optional
 
+import ctypes
 import _ctypes
 from comtypes import GUID
 
@@ -52,16 +53,30 @@ class AppView():
         return self._view.GetThumbnailWindow() # type: ignore
 
     @property
-    def app_id(self) -> Optional[int]:
+    def app_id(self) -> Optional[str]:
         """The ID of this window's app. Some specific types of windows do not have an app ID, and will return `None`.
         """
         try:
             # For certain types of windows, this will raise a COMError with 'Element not found'.
             # This seems to happen for things like window managers which are pinned above the normal windows.
             # Can be reliably reproduced with the 'f.lux' options window.
-            return self._view.GetAppUserModelId() # type: ignore
+            raw = self._view.GetAppUserModelId() # type: ignore
+            if raw is None:
+                return None
+            if isinstance(raw, str):
+                return raw
+            return ctypes.wstring_at(raw)
         except _ctypes.COMError:
             return None
+
+    @property
+    def base_app_id(self) -> Optional[str]:
+        """The canonical application ID, stripped of any window-hosting sub-identifiers (~Wh~).
+        """
+        app_id = self.app_id
+        if not app_id:
+            return None
+        return app_id.split("~Wh~")[0]
 
     @classmethod
     def current(cls):
@@ -126,23 +141,41 @@ class AppView():
 
     def pin_app(self):
         """
-        Pin this window's app (corresponds to the 'show windows from this app on all desktops' toggle).
+        Pin this window's app across all virtual desktops.
+        Pins the canonical app ID and ensures all active windows belonging
+        to this app (including hosted XAML Island windows) are pinned.
         """
-        app_id = self.app_id
+        base_id = self.base_app_id
         # This happens in rare cases. See the comment on app_id for more detail.
         # Returning without doing anything is the best we can do here, and matches the behaviour of the windows UI.
-        if app_id is None:
+        if base_id is None:
             return
-        managers.pinned_apps.PinAppID(self.app_id) # type: ignore
+        managers.pinned_apps.PinAppID(base_id) # type: ignore
+
+        # For applications using XAML Islands / window hosting (~Wh~),
+        # Windows assigns per-window sub-AUMIDs (~Wh~w<HWND>) and checks them
+        # via exact string matching. Pin the views of all active windows
+        # sharing this base app ID so they appear across all desktops immediately.
+        for view in get_apps_by_z_order(switcher_windows=False, current_desktop=False):
+            if view.base_app_id == base_id and view.app_id != base_id:
+                view.pin()
 
     def unpin_app(self):
         """
-        Unpin this window's app (corresponds to the 'show windows from this app on all desktops' toggle).
+        Unpin this window's app across all virtual desktops.
         """
-        app_id = self.app_id
-        if app_id is None:
+        base_id = self.base_app_id
+        if base_id is None:
             return
-        managers.pinned_apps.UnpinAppID(self.app_id) # type: ignore
+        managers.pinned_apps.UnpinAppID(base_id) # type: ignore
+
+        raw_id = self.app_id
+        if raw_id and raw_id != base_id:
+            managers.pinned_apps.UnpinAppID(raw_id) # type: ignore
+
+        for view in get_apps_by_z_order(switcher_windows=False, current_desktop=False):
+            if view.base_app_id == base_id and view.app_id != base_id:
+                view.unpin()
 
     def is_app_pinned(self) -> bool:
         """
@@ -151,10 +184,15 @@ class AppView():
         Returns:
             bool: is the app pinned?.
         """
-        app_id = self.app_id
-        if app_id is None:
-            return
-        return managers.pinned_apps.IsAppIdPinned(self.app_id) # type: ignore
+        base_id = self.base_app_id
+        if base_id is None:
+            return False
+        if managers.pinned_apps.IsAppIdPinned(base_id): # type: ignore
+            return True
+        raw_id = self.app_id
+        if raw_id and raw_id != base_id and managers.pinned_apps.IsAppIdPinned(raw_id): # type: ignore
+            return True
+        return False
 
 
     #  ------------------------------------------------
@@ -240,6 +278,22 @@ def get_apps_by_z_order(switcher_windows: bool = True, current_desktop: bool = T
             continue
         result.append(view)
     return result
+
+
+def sync_pinned_apps():
+    """Ensure all open windows belonging to a pinned application have their views pinned.
+    This handles hosted/XAML Island apps (e.g. Windows Terminal) where Windows COM
+    fails to automatically pin secondary windows due to synthetic ~Wh~ sub-AUMIDs.
+    """
+    pinned_cache: Dict[str, bool] = {}
+    for view in get_apps_by_z_order(switcher_windows=False, current_desktop=False):
+        base_id = view.base_app_id
+        if not base_id or view.app_id == base_id:
+            continue
+        if base_id not in pinned_cache:
+            pinned_cache[base_id] = bool(managers.pinned_apps.IsAppIdPinned(base_id)) # type: ignore
+        if pinned_cache[base_id] and not view.is_pinned():
+            view.pin()
 
 
 class VirtualDesktop():
@@ -396,6 +450,7 @@ class VirtualDesktop():
         """
         if allow_set_foreground:
             windll.user32.AllowSetForegroundWindow(ASFW_ANY)
+        sync_pinned_apps()
         managers.manager_internal.switch_desktop(self._virtual_desktop) # type: ignore
 
     def apps_by_z_order(self, include_pinned: bool = True) -> List[AppView]:

--- a/tests/test_desktop_functions.py
+++ b/tests/test_desktop_functions.py
@@ -7,7 +7,7 @@ import pytest
 import win32gui
 from comtypes import COINIT_MULTITHREADED, CoInitializeEx
 
-from pyvda import AppView, VirtualDesktop, get_apps_by_z_order, get_virtual_desktops
+from pyvda import AppView, VirtualDesktop, get_apps_by_z_order, get_virtual_desktops, sync_pinned_apps
 
 current_window = AppView.current()
 current_desktop = VirtualDesktop.current()
@@ -146,3 +146,16 @@ def test_initialisation_with_com_mta():
     t.join()
     if error is not None:
         raise error
+
+def test_base_app_id():
+    for app in get_apps_by_z_order(False, False):
+        if app.app_id:
+            assert isinstance(app.app_id, str)
+            assert isinstance(app.base_app_id, str)
+            if "~Wh~" in app.app_id:
+                assert app.base_app_id == app.app_id.split("~Wh~")[0]
+            else:
+                assert app.base_app_id == app.app_id
+
+def test_sync_pinned_apps():
+    sync_pinned_apps()


### PR DESCRIPTION
### Summary of Changes

Resolves an issue where pinning modern multi-window and XAML Island applications (such as Windows Terminal, modern File Explorer instances, and hosted Chromium/Electron frames) only pins isolated window instances rather than the entire application.

---

### Problem

Modern Windows applications hosting XAML controls inside Win32 frames assign per-window sub-AppUserModelIDs formatted as `<Package>!App~Wh~w<HEX_HWND>` (for example, `Microsoft.WindowsTerminal_8wekyb3d8bbwe!App~Wh~w010E0A34`).

Because Windows Shell's internal `IVirtualDesktopPinnedApps` COM interface performs exact string matching (`wcscmp`) against registered AppIDs:
1. **Sub-AUMID Isolation:** Calling `PinAppID()` with the raw window ID registers only that single transient window handle. Sibling windows under the same application remain unpinned, and closing the window leaves orphaned registry entries under `HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\VirtualDesktops\PinnedApps`.
2. **Shell String Mismatch:** Pinning only the base application ID fails to display existing secondary windows across desktops because their view identities carry the `~Wh~` suffix.
3. **Pointer Conversion Discrepancy:** On 64-bit runtimes, `GetAppUserModelId()` can return a raw pointer address rather than a decoded string, causing type errors downstream.

---

### Solution

1. **Decoded App ID & Canonical Base ID:**
   - In `AppView.app_id`, ensure raw pointer values are resolved to strings using `ctypes.wstring_at(raw)`.
   - Added `AppView.base_app_id`, which strips `~Wh~` window-hosting tokens to extract the canonical application identifier.

2. **Hierarchical Pinning and Unpinning:**
   - In `AppView.pin_app()`: Registers the `base_app_id` with `PinAppID()` and explicitly pins active sub-views belonging to that base ID via in-memory `PinView()`. This prevents orphaned registry keys while ensuring all active windows appear across workspaces.
   - In `AppView.unpin_app()`: Unpins both the base ID and window-specific IDs, and unpins matching active views.
   - In `AppView.is_app_pinned()`: Evaluates both `base_app_id` and raw `app_id` against `IsAppIdPinned()`.

3. **Desktop Transition Synchronization:**
   - Added `sync_pinned_apps()`, exported in `pyvda.__init__`. It inspects open views and pins individual sub-views for applications whose base ID is pinned.
   - Called `sync_pinned_apps()` inside `VirtualDesktop.go()` prior to switching desktops so secondary windows stay visible across desktops.

4. **Testing:**
   - Added unit tests in `tests/test_desktop_functions.py` validating `base_app_id` parsing and `sync_pinned_apps()` execution.

---

### Background Context & Deeper Architectural Notes

This fix is scoped to resolve the immediate XAML Island sub-AUMID bug cleanly with zero breaking changes. 

For maintainers interested in deeper architectural context, we have documented empirical investigations covering the Windows Virtual Desktop subsystem:
* **Native Shell Mechanics:** An analysis of how `explorer.exe` (`twinui.pcshell.dll`) manages Task View, the boundary between Microsoft's public SDK (`IVirtualDesktopManager`) and undocumented interfaces (`IVirtualDesktopManagerInternal`), and why out-of-process ALPC calls behave differently than in-process shell code.
* **Cross-Repository Analysis:** Comparative findings across `pyvda`, `VirtualDesktopAccessor` (Rust), `WinStasis` (C# .NET 10), and `ADCE` (Active Desktop Context Engine), noting that `VirtualDesktopAccessor` currently shares this exact `~Wh~` sub-AUMID pinning limitation.
* **COM Lifecycle Models:** Analysis comparing reactive exception retry decorators (`@_com_retry`) and broadcast listeners (`TaskbarCreated`) against call-scoped, zero-cached-state transient invocation models.

Research documents:
* [Multi-Window & XAML Island Application Pinning Architecture](https://github.com/amirf147/caster-user-directory-and-notes/blob/master/docs/pyvda/003_pyvda_multi_window_xaml_island_pinning_architecture.md)
* [Adversarial Audit, Native Windows Shell Architecture, & Resilient Client Design](https://github.com/amirf147/caster-user-directory-and-notes/blob/master/docs/pyvda/004_adversarial_audit_and_hardened_com_architecture.md)
